### PR TITLE
Merge product flavors abi to publish only one SDK

### DIFF
--- a/Platform/Android/build.gradle
+++ b/Platform/Android/build.gradle
@@ -39,7 +39,7 @@ buildscript {
         } else {
             //https://bintray.com/android/android-tools/com.android.tools.build.gradle/view
             classpath "com.android.tools.build:gradle:2.3.3"
-            classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7"
+            classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0"
         }
     }
 }

--- a/Platform/Android/lib/build_stable.gradle
+++ b/Platform/Android/lib/build_stable.gradle
@@ -52,20 +52,22 @@ android {
         }
     }
 
-    productFlavors {
-        if (!ndk_skipARM)
-            "arm" {
-                ndk.with {
-                    abiFilters = ["armeabi-v7a"]
+    if (ndk_skipARM || ndk_skipX86) {
+        productFlavors {
+            if (!ndk_skipARM)
+                "arm" {
+                    ndk.with {
+                        abiFilters = ["armeabi-v7a"]
+                    }
                 }
-            }
 
-        if (!ndk_skipX86)
-            "x86" {
-                ndk.with {
-                    abiFilters = ["x86"]
+            if (!ndk_skipX86)
+                "x86" {
+                    ndk.with {
+                        abiFilters = ["x86"]
+                    }
                 }
-            }
+        }
     }
 }
 

--- a/Platform/Android/lib/publish.gradle
+++ b/Platform/Android/lib/publish.gradle
@@ -31,7 +31,7 @@ publishing.publications {
          * Translates "_" in flavor names to "-" for artifactIds, because "-" in flavor name is an
          * illegal character, but is well used in artifactId names.
          */
-        def variantArtifactId = flavored ? variant.flavorName.replace('_', '-') : project.name
+        def variantArtifactId = flavored ? packageName + '-' + variant.flavorName.replace('_', '-') : packageName
 
         /**
          * If the javadoc destinationDir wasn't changed per flavor, the libraryVariants would
@@ -82,7 +82,7 @@ publishing.publications {
         publicationNames.add(publicationName)
 
         "$publicationName"(MavenPublication) {
-            artifactId packageName + '-' + variantArtifactId
+            artifactId variantArtifactId
             group groupId
             version libraryVersion
 


### PR DESCRIPTION
Product flavor cause publication of 2 SDK version : -arm and -x86. 
However, both version have armeabi-v7a and x86 .so files. 

To simplify sdk usage, I merged -arm and -x86 and published only one SDK readium-sdk-android. 
