### PR TITLE
Downgrade min sdk version

### DIFF
--- a/Platform/Android/lib/build_stable.gradle
+++ b/Platform/Android/lib/build_stable.gradle
@@ -16,7 +16,7 @@ android {
         // applicationId = "org.readium.sdk.android"
 
         // manifest/uses-sdk@android:minSdkVersion attribute in src/main/AndroidManifest.xml
-        minSdkVersion 19
+        minSdkVersion 17
 
         // manifest/uses-sdk@android:targetSdkVersion attribute in src/main/AndroidManifest.xml
         targetSdkVersion 26

--- a/Platform/Android/lib/build_stable.gradle
+++ b/Platform/Android/lib/build_stable.gradle
@@ -25,7 +25,7 @@ android {
         versionCode 29
 
         // manifest@android:versionName attribute in src/main/AndroidManifest.xml
-        versionName "1.29"
+        versionName "1.29.1"
     }
 
     sourceSets {
@@ -82,7 +82,7 @@ ext {
     packageRepo = "maven"
     packageName = "readium-sdk-android"
     packageOrganization = "youboox"
-    libraryVersion = "0.29.0"
+    libraryVersion = "0.29.1"
     libraryDesc = "Readium SDK (Android API)"
     siteUrl = 'https://github.com/readium/readium-sdk'
     gitUrl = 'https://github.com/readium/readium-sdk.git'

--- a/Platform/Android/lib/src/main/AndroidManifest.xml
+++ b/Platform/Android/lib/src/main/AndroidManifest.xml
@@ -20,6 +20,6 @@
     android:versionCode="29"
     android:versionName="1.29" >
 
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="26"/>
+    <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="26"/>
 
 </manifest>

--- a/Platform/Android/lib/src/main/AndroidManifest.xml
+++ b/Platform/Android/lib/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.readium.sdk.android"
     android:versionCode="29"
-    android:versionName="1.29" >
+    android:versionName="1.29.1" >
 
     <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="26"/>
 


### PR DESCRIPTION
To install readium-sdk on InkBook devices, downgrade android minSDK version from 19 to 17. 