### PR TITLE
Support Android SDK version 17

### DIFF
--- a/Platform/Android/lib/build_stable.gradle
+++ b/Platform/Android/lib/build_stable.gradle
@@ -25,7 +25,7 @@ android {
         versionCode 29
 
         // manifest@android:versionName attribute in src/main/AndroidManifest.xml
-        versionName "1.29.1"
+        versionName "1.29.2"
     }
 
     sourceSets {
@@ -82,7 +82,7 @@ ext {
     packageRepo = "maven"
     packageName = "readium-sdk-android"
     packageOrganization = "youboox"
-    libraryVersion = "0.29.1"
+    libraryVersion = "0.29.2"
     libraryDesc = "Readium SDK (Android API)"
     siteUrl = 'https://github.com/readium/readium-sdk'
     gitUrl = 'https://github.com/readium/readium-sdk.git'

--- a/Platform/Android/lib/src/main/java/org/readium/sdk/android/EPub3.java
+++ b/Platform/Android/lib/src/main/java/org/readium/sdk/android/EPub3.java
@@ -40,6 +40,8 @@ public class EPub3 {
 	 * Static Native library loader
 	 */
 	static {
+		// Load gnustl for Android SDK version 17
+		System.loadLibrary("gnustl_shared");
 		// Load the ePub3 Native lib
 		System.loadLibrary("epub3");
 	}


### PR DESCRIPTION
Load gnustl lib to support Android SDK version 17. 